### PR TITLE
pass --binary option to git diff

### DIFF
--- a/TryLib/RepoManager/Git.php
+++ b/TryLib/RepoManager/Git.php
@@ -103,8 +103,6 @@ class TryLib_RepoManager_Git implements TryLib_RepoManager {
 
         $args = array(
             "--binary",
-            "--src-prefix=''",
-            "--dst-prefix=''",
             "--no-color",
             $this->getUpstream(),
         );


### PR DESCRIPTION
so we can actually send & apply image differences (etc) to the ci server. In order to use this change CI will have to use git-apply instead of patch.
