### PR TITLE
support reading the patch file from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ TryLib currently supports **Freestyle** projects, when your test suite consist o
         -n, --diff-only         Create diff, but do not send to Hudson
         -v, --verbose           Verbose (show shell commands as they're run)
         -p, --patch ...         Path to patch file to use instead of generating a diff
+        -i, --patch-stdin       Read the patch from STDIN instead of a file
         -s, --staged            Use staged changes only to generate the diff
         -b, --branch ...        Remote branch to diff and try against [master]
         -w, --whitelist ...     Generate the patch for only the whitelisted files

--- a/TryLib/TryRunner/Options.php
+++ b/TryLib/TryRunner/Options.php
@@ -12,6 +12,7 @@ h,help             Show help
 n,diff-only        Create diff, but do not send to Hudson
 v,verbose          Verbose (show shell commands as they're run)
 p,patch=           Path to patch file to use instead of generating a diff
+i,patch-stdin      Read the patch to use from STDIN instead of a file
 s,staged           Use staged changes only to generate the diff
 w,whitelist=       Generate the patch for only the whitelisted files
 b,branch=          Remote branch to diff and try against [\$default_remote_branch]

--- a/TryLib/TryRunner/Runner.php
+++ b/TryLib/TryRunner/Runner.php
@@ -56,6 +56,9 @@ final class TryLib_TryRunner_Runner {
         $this->repo_manager->runPrechecks($this->prechecks);
 
         $patch = $options->patch;
+        if ($options->patch_stdin) {
+            $patch = $this->readPatchFromStdin($options->wcpath);
+        }
         if (is_null($patch)) {
             $patch = $this->repo_manager->generateDiff($options->staged, $whitelist);
         }
@@ -80,5 +83,12 @@ final class TryLib_TryRunner_Runner {
 
         $this->jenkins_runner->startJenkinsJob($options->show_results, $options->show_progress);
         return ($this->jenkins_runner->try_status === 'FAILURE') ? 1 : 0;
+    }
+
+    private function readPatchFromStdin($patch_dir) {
+        $patch_file = "$patch_dir/patch.diff";
+        $input = file_get_contents('php://stdin');
+        file_put_contents($patch_file, $input);
+        return $patch_file;
     }
 }

--- a/TryLib/Util/PHPOptions/Options.php
+++ b/TryLib/Util/PHPOptions/Options.php
@@ -318,6 +318,11 @@ function _tty_width() {
     if (PHP_OS != "Linux")
         return 80;
 
+    $isatty = defined('STDIN') && posix_isatty(STDIN);
+    if (!$isatty) {
+        return 80;
+    }
+
     $dims = explode(" ", shell_exec("stty size"));
     return intval($dims[1]);
 }
@@ -373,6 +378,7 @@ class TryLib_Util_PHPOptions_Options {
         }
         array_push($out, "\n");
         $last_was_option = False;
+        $tty_width = _tty_width();
         while (count($lines)) {
             $l = array_pop($lines);
             if (_startswith($l, ' ')) {
@@ -425,7 +431,7 @@ class TryLib_Util_PHPOptions_Options {
                 // so the text will wrap to the beginning of the line. We could
                 // implement this to make the usage string look nicer, but it
                 // would probably imply too much code for what it's worth.
-                $argtext = wordwrap($prefix . $extra, _tty_width());
+                $argtext = wordwrap($prefix . $extra, $tty_width);
                 array_push($out, $argtext . "\n");
                 $last_was_option = True;
             } else {


### PR DESCRIPTION
right now I can `git diff > patch.diff && try -p patch.diff`
but it would be easier if I could just do `git diff | try -i`

This patch makes that possible. --patch-stdin is the flag that
tells try to read from stdin instead of the patch.diff file. It
writes stdin straight through to patch.diff and then everything
else continues to work as before.

This did expose one bug which is fixed in
TryLib/Util/PHPOptions/Options.php.
The `stty size` command doesn't run when try is being piped input
from another source. The width did not work in that case and there
was lots of bad output. Now it checks first to see if stdin is a tty
and if not just uses 80.
