### PR TITLE
Add support for git-diff's '-U' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ TryLib currently supports **Freestyle** projects, when your test suite consist o
     $ try -h
     usage: try [options...] [subjob] [subjob] ...
 
-        -h, --help              Show help
-        -n, --diff-only         Create diff, but do not send to Hudson
-        -v, --verbose           Verbose (show shell commands as they're run)
-        -p, --patch ...         Path to patch file to use instead of generating a diff
-        -i, --patch-stdin       Read the patch from STDIN instead of a file
-        -s, --staged            Use staged changes only to generate the diff
-        -b, --branch ...        Remote branch to diff and try against [master]
-        -w, --whitelist ...     Generate the patch for only the whitelisted files
+        -h, --help            Show help
+        -n, --diff-only       Create diff, but do not send to Hudson
+        -v, --verbose         Verbose (show shell commands as they're run)
+        -p, --patch ...       Path to patch file to use instead of generating a diff
+        -U, --lines-of-context ...  Generate a diff with n lines of context (like git-diff's -U option)
+        -s, --staged          Use staged changes only to generate the diff
+        -w, --whitelist ...   Generate the patch for only the whitelisted files
+        -b, --branch ...      Remote branch to diff and try against [master]
 
-        -c, --show-results      Show final try job results
-        -P, --show-progress     Print subtasks progressively as they complete
-        --extra-param ...       Extra parameters to send to jenkins - format key=value
-        -C, --callback ...      Callback string to execute at the end of the try run.
+        -c, --show-results    Show final try job results
+        -P, --show-progress   Print subtasks progressively as they complete
+        --extra-param ...     Extra parameters to send to jenkins - format key=value
+        -C, --callback ...    Callback string to execute at the end of the try run.
 
     Use ${status} and ${url} as placeholders for the try build status and url
     Example: --callback 'echo "**Try status : [${status}](${url})**"'
 
-        --jenkinsjob ...        Master Job Name in Jenkins  [try]
+        --jenkinsjob ...      Master Job Name in Jenkins  [try]
         --jenkinsjobprefix ...  Subjobs prefix              [try]
-        --jenkinsserver ...     URL to the jenkins server   [localhost:8080]
-        --wcpath ...            Working Copy Path           [.]
+        --jenkinsserver ...   URL to the jenkins server   [localhost:8080]
+        --wcpath ...          Working Copy Path           [.]
 
 ### Run try on FreeStyle project and show the results in the console.
     $ try --show-results

--- a/TryLib/RepoManager/Git.php
+++ b/TryLib/RepoManager/Git.php
@@ -97,7 +97,7 @@ class TryLib_RepoManager_Git implements TryLib_RepoManager {
         return $remote . "/" . $remote_branch;
     }
 
-    function generateDiff($staged_only = false, $whitelist = null) {
+    function generateDiff($staged_only = false, $whitelist = null, $lines_of_context = false) {
         $patch = $this->repo_path . "/patch.diff";
 
         $args = array(
@@ -108,6 +108,11 @@ class TryLib_RepoManager_Git implements TryLib_RepoManager {
 
         if ($staged_only) {
             $args[] = "--staged";
+        }
+
+        # User is requesting additional lines of context around changes.
+        if ($lines_of_context) {
+            $args[] = "-U{$lines_of_context}";
         }
 
         if (is_array($whitelist)) {

--- a/TryLib/TryRunner/Options.php
+++ b/TryLib/TryRunner/Options.php
@@ -8,26 +8,27 @@ final class TryLib_TryRunner_Options {
     const USAGE_SPEC = "
 try [options...] [subjob] [subjob] ...
 --
-h,help             Show help
-n,diff-only        Create diff, but do not send to Hudson
-v,verbose          Verbose (show shell commands as they're run)
-p,patch=           Path to patch file to use instead of generating a diff
-i,patch-stdin      Read the patch to use from STDIN instead of a file
-s,staged           Use staged changes only to generate the diff
-w,whitelist=       Generate the patch for only the whitelisted files
-b,branch=          Remote branch to diff and try against [\$default_remote_branch]
+h,help                Show help
+n,diff-only           Create diff, but do not send to Hudson
+v,verbose             Verbose (show shell commands as they're run)
+p,patch=              Path to patch file to use instead of generating a diff
+U,lines-of-context=   Generate a diff with n lines of context (like git-diff's -U option)
+i,patch-stdin         Read the patch to use from STDIN instead of a file
+s,staged              Use staged changes only to generate the diff
+w,whitelist=          Generate the patch for only the whitelisted files
+b,branch=             Remote branch to diff and try against [\$default_remote_branch]
 
-c,show-results     Show final try job results
-P,show-progress    Print subtasks progressively as they complete
-extra-param=       Extra parameters to send to jenkins - format key=value
-C,callback=        Callback string to execute at the end of the try run.
-                   Use \${status} and \${url} as placeholders for the try build status and url
-                   Example: --callback 'echo \"**Try status : [\${status}](\${url})**\"'
+c,show-results        Show final try job results
+P,show-progress       Print subtasks progressively as they complete
+extra-param=          Extra parameters to send to jenkins - format key=value
+C,callback=           Callback string to execute at the end of the try run.
+                      Use \${status} and \${url} as placeholders for the try build status and url
+                      Example: --callback 'echo \"**Try status : [\${status}](\${url})**\"'
 
-jenkinsjob=        Master Job Name in Jenkins  [\$default_jenkins_job]
-jenkinsjobprefix=  Subjobs prefix              [\$default_jenkins_job_prefix]
-jenkinsserver=     URL to the jenkins server   [\$jenkins_server]
-wcpath=            Working Copy Path           [\$default_wc_path]
+jenkinsjob=           Master Job Name in Jenkins  [\$default_jenkins_job]
+jenkinsjobprefix=     Subjobs prefix              [\$default_jenkins_job_prefix]
+jenkinsserver=        URL to the jenkins server   [\$jenkins_server]
+wcpath=               Working Copy Path           [\$default_wc_path]
 ";
 
     private function __construct() {}  // Do not instantiate.

--- a/TryLib/TryRunner/Runner.php
+++ b/TryLib/TryRunner/Runner.php
@@ -59,8 +59,12 @@ final class TryLib_TryRunner_Runner {
         if ($options->patch_stdin) {
             $patch = $this->readPatchFromStdin($options->wcpath);
         }
+        $lines_of_context = false;
+        if ($options->lines_of_context) {
+            $lines_of_context = $options->lines_of_context;
+        }
         if (is_null($patch)) {
-            $patch = $this->repo_manager->generateDiff($options->staged, $whitelist);
+            $patch = $this->repo_manager->generateDiff($options->staged, $whitelist, $lines_of_context);
         }
 
         if ($options->diff_only) {

--- a/tests/phpunit/TryRunner/RunnerTest.php
+++ b/tests/phpunit/TryRunner/RunnerTest.php
@@ -11,7 +11,7 @@ class TryRunner_RunnerTest extends PHPUnit_Framework_TestCase {
 
     public function testSimple() {
         $options_tuple = TryLib_TryRunner_Options::parse(
-            array("--branch", "testbranch"),
+            array("--branch", "testbranch", "-U", 10),
             "jenkins_job",
             "jenkins_job_prefix",
             "jenkins_server",
@@ -19,6 +19,7 @@ class TryRunner_RunnerTest extends PHPUnit_Framework_TestCase {
 
         $repo_manager = new TryRunner_RunnerTest__TestRepoManager();
         $jenkins_runner = new TryRunner_RunnerTest__TestJenkinsRunner();
+        list($options, $flags, $extra) = $options_tuple;
 
         $try_runner = new TryLib_TryRunner_Runner(
             $repo_manager,
@@ -37,6 +38,7 @@ class TryRunner_RunnerTest extends PHPUnit_Framework_TestCase {
         $this->assertTrue($repo_manager->ran_prechecks);
         $this->assertContains("some CLI command", $jenkins_runner->commands_run);
         $this->assertEquals("/test/ssh/key/path", $jenkins_runner->ssh_key_path);
+        $this->assertEquals(10, $options->lines_of_context);
     }
 
     /**

--- a/try
+++ b/try
@@ -26,25 +26,26 @@ $default_wc_path = '.';
 $usage_spec = "
 try [options...] [subjob] [subjob] ...
 --
-h,help              Show help
-n,diff-only         Create diff, but do not send to Hudson
-v,verbose           Verbose (show shell commands as they're run)
-p,patch=            Path to patch file to use instead of generating a diff
-s,staged            Use staged changes only to generate the diff
-w,whitelist=        Generate the patch for only the whitelisted files
-b,branch=           Remote branch to diff and try against [master]
+h,help                Show help
+n,diff-only           Create diff, but do not send to Hudson
+v,verbose             Verbose (show shell commands as they're run)
+p,patch=              Path to patch file to use instead of generating a diff
+U,lines-of-context=   Generate a diff with n lines of context (like git-diff's -U option)
+s,staged              Use staged changes only to generate the diff
+w,whitelist=          Generate the patch for only the whitelisted files
+b,branch=             Remote branch to diff and try against [master]
 
-c,show-results      Show final try job results
-P,show-progress     Print subtasks progressively as they complete
-extra-param=        Extra parameters to send to jenkins - format key=value
-C,callback=         Callback string to execute at the end of the try run.
-                    Use \${status} and \${url} as placeholders for the try build status and url
-                    Example: --callback 'echo \"**Try status : [\${status}](\${url})**\"'
+c,show-results        Show final try job results
+P,show-progress       Print subtasks progressively as they complete
+extra-param=          Extra parameters to send to jenkins - format key=value
+C,callback=           Callback string to execute at the end of the try run.
+                      Use \${status} and \${url} as placeholders for the try build status and url
+                      Example: --callback 'echo \"**Try status : [\${status}](\${url})**\"'
 
-jenkinsjob=         Master Job Name in Jenkins  [$default_jenkins_job]
-jenkinsjobprefix=   Subjobs prefix              [$default_jenkins_job_prefix]
-jenkinsserver=      URL to the jenkins server   [$jenkins_server]
-wcpath=             Working Copy Path           [$default_wc_path]
+jenkinsjob=           Master Job Name in Jenkins  [$default_jenkins_job]
+jenkinsjobprefix=     Subjobs prefix              [$default_jenkins_job_prefix]
+jenkinsserver=        URL to the jenkins server   [$jenkins_server]
+wcpath=               Working Copy Path           [$default_wc_path]
 ";
 
 # Parse options


### PR DESCRIPTION
- There may be cases where folks want `try` to generate a diff with more than the default number of lines of context (3) around changes.
- This commit adds support for the `-U` option just like what git-diff supports.
- Updated documentation, usage specs, and tests, accordingly.