### PR TITLE
Deprecate "blacklist" and "whitelist" in favor of "blocklist" and "safelist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TryLib currently supports **Freestyle** projects, when your test suite consist o
         -p, --patch ...       Path to patch file to use instead of generating a diff
         -U, --lines-of-context ...  Generate a diff with n lines of context (like git-diff's -U option)
         -s, --staged          Use staged changes only to generate the diff
-        -w, --whitelist ...   Generate the patch for only the whitelisted files
+        -w, --safelist ...    Generate the patch for only the safelisted files
         -b, --branch ...      Remote branch to diff and try against [master]
 
         -c, --show-results    Show final try job results

--- a/TryLib/Precheck/GitWarnOnBlacklisted.php
+++ b/TryLib/Precheck/GitWarnOnBlacklisted.php
@@ -6,7 +6,7 @@
 class TryLib_Precheck_GitWarnOnBlacklisted implements TryLib_Precheck {
 
     function __construct(array $blocklist, $safelist = null, $staged = false) {
-		$warning = "[DEPRECATION] 'TryLib_Precheck_GitWarnOnBlacklisted'. ";
+		$warning = "[DEPRECATION] 'TryLib_Precheck_GitWarnOnBlacklisted' is deprecated. ";
 		$warning .= "Please use 'TryLib_Precheck_GitWarnOnBlocklisted' instead." . PHP_EOL;
 		trigger_error($warning);
 	    $this->check = new TryLib_Precheck_GitWarnOnBlocklisted($blocklist, $safelist, $staged);

--- a/TryLib/Precheck/GitWarnOnBlacklisted.php
+++ b/TryLib/Precheck/GitWarnOnBlacklisted.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @deprecated
+ */
+class TryLib_Precheck_GitWarnOnBlacklisted implements TryLib_Precheck {
+
+    function __construct(array $blocklist, $safelist = null, $staged = false) {
+		$warning = "[DEPRECATION] 'TryLib_Precheck_GitWarnOnBlacklisted'. ";
+		$warning .= "Please use 'TryLib_Precheck_GitWarnOnBlocklisted' instead." . PHP_EOL;
+		trigger_error($warning);
+	    $this->check = new TryLib_Precheck_GitWarnOnBlocklisted($blocklist, $safelist, $staged);
+	}
+
+    function check($cmd_runner, $repo_path, $upstream) {
+		$this->check->check($cmd_runner, $repo_path, $upstream);
+
+	}
+
+}

--- a/TryLib/Precheck/GitWarnOnBlocklisted.php
+++ b/TryLib/Precheck/GitWarnOnBlocklisted.php
@@ -1,21 +1,21 @@
 <?php
 
 /**
-  * Warn a user if there are any blacklisted files in the patch
+  * Warn a user if there are any blocklisted files in the patch
   */
-class TryLib_Precheck_GitWarnOnBlacklisted implements TryLib_Precheck {
-    protected $blacklist;
+class TryLib_Precheck_GitWarnOnBlocklisted implements TryLib_Precheck {
+    protected $blocklist;
     protected $whitelist;
     protected $staged;
 
-    function __construct(array $blacklist, $whitelist = null, $staged = false) {
+    function __construct(array $blocklist, $whitelist = null, $staged = false) {
         $this->whitelist = $whitelist ?: array();
-        $this->blacklist = array_diff($blacklist, $this->whitelist);
+        $this->blocklist = array_diff($blocklist, $this->whitelist);
         $this->staged = $staged;
     }
 
     /**
-     * Warn the user if the changed files contain any blacklisted files
+     * Warn the user if the changed files contain any blocklisted files
      *
      * @param CommandRunner $cmd_runner  cmd runner object
      * @param string        $repo_path          location of the git repo
@@ -36,17 +36,17 @@ class TryLib_Precheck_GitWarnOnBlacklisted implements TryLib_Precheck {
 
         $changed_files = $cmd_runner->getOutput();
 
-        $blacklisted_changed_files = array();
+        $blocklisted_changed_files = array();
 
         foreach (explode(PHP_EOL, $changed_files) as $file) {
-            if (in_array($file, $this->blacklist)) {
-                $blacklisted_changed_files[] = $file;
+            if (in_array($file, $this->blocklist)) {
+                $blocklisted_changed_files[] = $file;
             }
         }
 
-        if (!empty($blacklisted_changed_files)) {
-            $msg = 'The diff you are trying to submit contains the following blacklisted file(s) : ';
-            $msg .= implode(',', $blacklisted_changed_files);
+        if (!empty($blocklisted_changed_files)) {
+            $msg = 'The diff you are trying to submit contains the following blocklisted file(s) : ';
+            $msg .= implode(',', $blocklisted_changed_files);
             $cmd_runner->warn($msg);
         }
     }

--- a/TryLib/Precheck/GitWarnOnBlocklisted.php
+++ b/TryLib/Precheck/GitWarnOnBlocklisted.php
@@ -5,12 +5,12 @@
   */
 class TryLib_Precheck_GitWarnOnBlocklisted implements TryLib_Precheck {
     protected $blocklist;
-    protected $whitelist;
+    protected $safelist;
     protected $staged;
 
-    function __construct(array $blocklist, $whitelist = null, $staged = false) {
-        $this->whitelist = $whitelist ?: array();
-        $this->blocklist = array_diff($blocklist, $this->whitelist);
+    function __construct(array $blocklist, $safelist = null, $staged = false) {
+        $this->safelist = $safelist ?: array();
+        $this->blocklist = array_diff($blocklist, $this->safelist);
         $this->staged = $staged;
     }
 
@@ -28,8 +28,8 @@ class TryLib_Precheck_GitWarnOnBlocklisted implements TryLib_Precheck {
             $cmd .= ' --staged';
         }
 
-        if (!empty($this->whitelist)) {
-            $cmd .= ' ' . implode(' ', $this->whitelist);
+        if (!empty($this->safelist)) {
+            $cmd .= ' ' . implode(' ', $this->safelist);
         }
 
         $cmd_runner->run($cmd);

--- a/TryLib/RepoManager/Git.php
+++ b/TryLib/RepoManager/Git.php
@@ -97,7 +97,7 @@ class TryLib_RepoManager_Git implements TryLib_RepoManager {
         return $remote . "/" . $remote_branch;
     }
 
-    function generateDiff($staged_only = false, $whitelist = null, $lines_of_context = false) {
+    function generateDiff($staged_only = false, $safelist = null, $lines_of_context = false) {
         $patch = $this->repo_path . "/patch.diff";
 
         $args = array(
@@ -115,8 +115,8 @@ class TryLib_RepoManager_Git implements TryLib_RepoManager {
             $args[] = "-U{$lines_of_context}";
         }
 
-        if (is_array($whitelist)) {
-            $args[] = implode(' ', $whitelist);
+        if (is_array($safelist)) {
+            $args[] = implode(' ', $safelist);
         }
 
         $this->cmd_runner->chdir($this->repo_path);

--- a/TryLib/TryRunner/Builder.php
+++ b/TryLib/TryRunner/Builder.php
@@ -18,7 +18,7 @@ final class TryLib_TryRunner_Builder {
 
     private $project_type = null;
     private $jenkins_cli_jar_path = null;
-    private $whitelisted_files = null;
+    private $safelisted_files = null;
     private $override_user = null;
     private $prechecks = null;
     private $options_tuple = null;
@@ -67,7 +67,7 @@ final class TryLib_TryRunner_Builder {
             $repo_manager,
             $jenkins_runner,
             $this->jenkins_cli_jar_path,
-            $this->whitelisted_files,
+            $this->safelisted_files,
             $this->override_user,
             $this->prechecks,
             $this->options_tuple,
@@ -81,12 +81,12 @@ final class TryLib_TryRunner_Builder {
 
     /**
      * An array of the only paths in your local working copy to include in a diff. Overriden by
-     * the command line option --whitelist.
+     * the command line option --safelist.
      *
      * Defaults to an empty array.
      */
-    public function whitelistedFiles(array $whitelisted_files) {
-        $this->whitelisted_files = $whitelisted_files;
+    public function safelistedFiles(array $safelisted_files) {
+        $this->safelisted_files = $safelisted_files;
         return $this;
     }
 

--- a/TryLib/TryRunner/Options.php
+++ b/TryLib/TryRunner/Options.php
@@ -15,7 +15,7 @@ p,patch=              Path to patch file to use instead of generating a diff
 U,lines-of-context=   Generate a diff with n lines of context (like git-diff's -U option)
 i,patch-stdin         Read the patch to use from STDIN instead of a file
 s,staged              Use staged changes only to generate the diff
-w,whitelist=          Generate the patch for only the whitelisted files
+w,whitelist,safelist= Generate the patch for only the safelisted files
 b,branch=             Remote branch to diff and try against [\$default_remote_branch]
 
 c,show-results        Show final try job results

--- a/TryLib/TryRunner/Runner.php
+++ b/TryLib/TryRunner/Runner.php
@@ -15,7 +15,7 @@ final class TryLib_TryRunner_Runner {
             $repo_manager,
             $jenkins_runner,
             $jenkins_cli_jar_path,
-            $whitelisted_files,
+            $safelisted_files,
             $override_user,
             $prechecks,
             $options_tuple,
@@ -23,7 +23,7 @@ final class TryLib_TryRunner_Runner {
         $this->repo_manager = self::requireArg($repo_manager);
         $this->jenkins_runner = self::requireArg($jenkins_runner);
         $this->jenkins_cli_jar_path = self::requireArg($jenkins_cli_jar_path);
-        $this->whitelisted_files = $whitelisted_files ?: array();
+        $this->safelisted_files = $safelisted_files ?: array();
         $this->override_user = $override_user ?: getenv("USER");
         $this->prechecks = $prechecks ?: array();
         $this->options_tuple = self::requireArg($options_tuple);
@@ -44,13 +44,13 @@ final class TryLib_TryRunner_Runner {
         // Resolve the given remote branch value to a real ref.
         $remote_branch = $this->repo_manager->getRemoteBranch();
 
-        if ($options->whitelist) {
-            $whitelist = $options->whitelist;
-            if (is_string($whitelist)) {
-                $whitelist = array($whitelist);
+        if ($options->safelist) {
+            $safelist = $options->safelist;
+            if (is_string($safelist)) {
+                $safelist = array($safelist);
             }
         } else {
-            $whitelist = $this->whitelisted_files;
+            $safelist = $this->safelisted_files;
         }
 
         $this->repo_manager->runPrechecks($this->prechecks);
@@ -64,7 +64,7 @@ final class TryLib_TryRunner_Runner {
             $lines_of_context = $options->lines_of_context;
         }
         if (is_null($patch)) {
-            $patch = $this->repo_manager->generateDiff($options->staged, $whitelist, $lines_of_context);
+            $patch = $this->repo_manager->generateDiff($options->staged, $safelist, $lines_of_context);
         }
 
         if ($options->diff_only) {

--- a/package.xml
+++ b/package.xml
@@ -53,6 +53,7 @@
           <file name="GitCopyAge.php" role="php" />
           <file name="GitCopyBehind.php" role="php" />
           <file name="GitReportUntracked.php" role="php" />
+          <file name="GitWarnOnBlacklisted.php" role="php" />
           <file name="GitWarnOnBlocklisted.php" role="php" />
         </dir>
         <dir name="TryRunner">

--- a/package.xml
+++ b/package.xml
@@ -53,7 +53,7 @@
           <file name="GitCopyAge.php" role="php" />
           <file name="GitCopyBehind.php" role="php" />
           <file name="GitReportUntracked.php" role="php" />
-          <file name="GitWarnOnBlacklisted.php" role="php" />
+          <file name="GitWarnOnBlocklisted.php" role="php" />
         </dir>
         <dir name="TryRunner">
           <file name="Builder.php" role="php" />

--- a/tests/phpunit/Precheck/GitWarnOnBlocklistedTest.php
+++ b/tests/phpunit/Precheck/GitWarnOnBlocklistedTest.php
@@ -77,7 +77,7 @@ class GitWarnOnBlocklistedTest extends PHPUnit_Framework_TestCase {
 
     }
 
-    function testWithWhiteListedFiles() {
+    function testWithSafeListedFiles() {
         $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array(),
             array('my/foo.php', 'my/bar.php'),
@@ -100,7 +100,7 @@ class GitWarnOnBlocklistedTest extends PHPUnit_Framework_TestCase {
 
     }
 
-    function testWithWhiteListedAndBlockListedFiles() {
+    function testWithSafeListedAndBlockListedFiles() {
         $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array('my/bar.php'),
             array('my/foo.php', 'my/bar.php'),

--- a/tests/phpunit/Precheck/GitWarnOnBlocklistedTest.php
+++ b/tests/phpunit/Precheck/GitWarnOnBlocklistedTest.php
@@ -2,14 +2,14 @@
 
 require_once "TryLib/Autoload.php";
 
-class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
+class GitWarnOnBlocklistedTest extends PHPUnit_Framework_TestCase {
     function setUp() {
         parent::setUp();
         $this->mock_cmd_runner = $this->getMock('TryLib_CommandRunner');
     }
 
     function testNoChanges() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array(),
             null,
             false
@@ -31,8 +31,8 @@ class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
         $script_runner->check($this->mock_cmd_runner, 'repoPath', 'some/origin');
     }
 
-    function testNoBlackListedFiles() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+    function testNoBlockListedFiles() {
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array('my/foo.php'),
             false,
             false
@@ -54,8 +54,8 @@ class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
 
     }
 
-    function testWithBlackListedFiles() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+    function testWithBlockListedFiles() {
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array('my/foo.php', 'my/bar.php'),
             null,
             false
@@ -78,7 +78,7 @@ class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
     }
 
     function testWithWhiteListedFiles() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array(),
             array('my/foo.php', 'my/bar.php'),
             false
@@ -100,8 +100,8 @@ class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
 
     }
 
-    function testWithWhiteListedAndBlackListedFiles() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+    function testWithWhiteListedAndBlockListedFiles() {
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array('my/bar.php'),
             array('my/foo.php', 'my/bar.php'),
             false
@@ -123,7 +123,7 @@ class GitWarnOnBlacklistedTest extends PHPUnit_Framework_TestCase {
     }
 
     function testStagedOnly() {
-        $script_runner = new TryLib_Precheck_GitWarnOnBlacklisted(
+        $script_runner = new TryLib_Precheck_GitWarnOnBlocklisted(
             array('my/foo.php', 'my/bar.php'),
             null,
             true

--- a/try
+++ b/try
@@ -32,7 +32,7 @@ v,verbose             Verbose (show shell commands as they're run)
 p,patch=              Path to patch file to use instead of generating a diff
 U,lines-of-context=   Generate a diff with n lines of context (like git-diff's -U option)
 s,staged              Use staged changes only to generate the diff
-w,whitelist=          Generate the patch for only the whitelisted files
+w,safelist=           Generate the patch for only the safelisted files
 b,branch=             Remote branch to diff and try against [master]
 
 c,show-results        Show final try job results
@@ -81,9 +81,9 @@ $jenkins_runner = new TryLib_JenkinsRunner_MasterProject(
     $options->jenkinsjobprefix
 );
 
-$whitelist = $options->whitelist;
-if (is_string($whitelist)) {
-    $whitelist = array($whitelist);
+$safelist = $options->safelist;
+if (is_string($safelist)) {
+    $safelist = array($safelist);
 }
 
 $pre_checks = array(
@@ -95,7 +95,7 @@ $repo_manager->runPrechecks($pre_checks);
 
 $patch = $options->patch;
 if (is_null($patch)) {
-    $patch = $repo_manager->generateDiff($options->staged, $whitelist);
+    $patch = $repo_manager->generateDiff($options->staged, $safelist);
 }
 
 if ($options->diff_only) {


### PR DESCRIPTION
As suggested by Vanessa Hurst (@DBNess), this PR deprecates the "blacklist" in favor of "blocklist" and renames the whitelist arguments into safelist. 

In her own words : "Led by Travis CI developer Renée Hendricksen, Kickstarter and others have replaced "whitelist" with "safelist" (to indicate an approved list) and "blacklist" with "blocklist" (to indicate a disapproved list) in their codebases"