### PR TITLE
Add a getPathPatch method to TryRunner

### DIFF
--- a/src/TryRunner/Runner.php
+++ b/src/TryRunner/Runner.php
@@ -33,6 +33,7 @@ final class Runner {
         $this->prechecks = $prechecks ?: array();
         $this->options_tuple = self::requireArg($options_tuple);
         $this->ssh_key_path = $ssh_key_path;
+        $this->patch = null;
     }
 
     private static function requireArg($arg) {
@@ -42,40 +43,53 @@ final class Runner {
         return $arg;
     }
 
+    public function getPatchLocation() {
+        if (is_null($this->patch)) {
+            list($options, $flags, $extra) = $this->options_tuple;
+
+            $this->repo_manager->setRemoteBranch($options->branch);
+
+            // Resolve the given remote branch value to a real ref.
+            $remote_branch = $this->repo_manager->getRemoteBranch();
+
+            // Set the remote branch parameter
+            $this->jenkins_runner->setParam('branch', $remote_branch);
+
+            if ($options->safelist) {
+                $safelist = $options->safelist;
+                if (is_string($safelist)) {
+                    $safelist = array($safelist);
+                }
+            } else {
+                $safelist = $this->safelisted_files;
+            }
+
+            $this->patch = $options->patch;
+            if ($options->patch_stdin) {
+                $this->patch = $this->readPatchFromStdin($options->wcpath);
+            }
+            $lines_of_context = false;
+            if ($options->lines_of_context) {
+                $lines_of_context = $options->lines_of_context;
+            }
+            if (is_null($this->patch)) {
+                $this->patch = $this->repo_manager->generateDiff($options->staged, $safelist, $lines_of_context);
+            }
+
+            if (0 == filesize(realpath($this->patch))) {
+                $this->printWarningSign();
+                print "\nThe patch file is empty! There are no local changes.\n\nContinuing Try...\n\n";
+            }
+        }
+        return $this->patch;
+    }
+
     public function run() {
         list($options, $flags, $extra) = $this->options_tuple;
 
-        $this->repo_manager->setRemoteBranch($options->branch);
-        // Resolve the given remote branch value to a real ref.
-        $remote_branch = $this->repo_manager->getRemoteBranch();
-
-        if ($options->safelist) {
-            $safelist = $options->safelist;
-            if (is_string($safelist)) {
-                $safelist = array($safelist);
-            }
-        } else {
-            $safelist = $this->safelisted_files;
-        }
+        $patch = $this->getPatchLocation();
 
         $this->repo_manager->runPrechecks($this->prechecks);
-
-        $patch = $options->patch;
-        if ($options->patch_stdin) {
-            $patch = $this->readPatchFromStdin($options->wcpath);
-        }
-        $lines_of_context = false;
-        if ($options->lines_of_context) {
-            $lines_of_context = $options->lines_of_context;
-        }
-        if (is_null($patch)) {
-            $patch = $this->repo_manager->generateDiff($options->staged, $safelist, $lines_of_context);
-        }
-
-        if (0 == filesize(realpath($patch))) {
-            $this->printWarningSign();
-            print "\nThe patch file is empty! There are no local changes.\n\nContinuing Try...\n\n";
-        }
 
         if ($options->diff_only) {
             print 'Not sending job to Jenkins (-n) diff is here:' . $patch . PHP_EOL;
@@ -86,7 +100,6 @@ final class Runner {
         if ($this->ssh_key_path) {
             $this->jenkins_runner->setSshKey($this->ssh_key_path);
         }
-        $this->jenkins_runner->setParam('branch', $remote_branch);
         $this->jenkins_runner->setParam('guid', $this->override_user . time());
 
         $extra_params = OptionsUtil::parseExtraParameters($options->extra_param);

--- a/tests/TryRunner/RunnerTest.php
+++ b/tests/TryRunner/RunnerTest.php
@@ -24,7 +24,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
             "/path/to/working/copy");
 
         $repo_manager = new TestRepoManager();
-        $jenkins_runner = new TestJenkinsRunner();
+        $jenkins_runner = new TestJenkinsRunner('http://jenkins.com', null, null, null);
         list($options, $flags, $extra) = $options_tuple;
 
         $try_runner = new Runner(
@@ -64,7 +64,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
             null  /* Set no default remote, to enable branch auto-detection. */);
 
         $repo_manager = new TestRepoManagerWithDetectedBranch();
-        $jenkins_runner = new TestJenkinsRunner();
+        $jenkins_runner = new TestJenkinsRunner('http://jenkins.com', null, null, null);
 
         $try_runner = new Runner(
             $repo_manager,
@@ -131,8 +131,6 @@ class TestJenkinsRunner extends JenkinsRunner {
 
     public $commands_run = array();
     public $ssh_key_path = null;
-
-    public function __construct() {}
 
     protected function pollForCompletion($pretty) {}
 


### PR DESCRIPTION
The main motivation for this new method is to add the ability to run additional code on the patch,
prior to running try.