### PR TITLE
Fix 'Indirect modification of overloaded element' error.

### DIFF
--- a/src/Util/PHPOptions/Options.php
+++ b/src/Util/PHPOptions/Options.php
@@ -515,7 +515,7 @@ class Options {
                     $opt[$k] = array($opt[$k], $val);
                 } else {
                     # Need an intermediary to modify here because $opt[$k] returns
-                    # a scalar not a reference, so modifying it directly doesn't do much.
+                    # a scalar not a reference, so modifying errors out.
                     $intermediary = $opt[$k];
                     $intermediary[] = $val;
                     $opt[$k] = $intermediary;

--- a/src/Util/PHPOptions/Options.php
+++ b/src/Util/PHPOptions/Options.php
@@ -514,7 +514,11 @@ class Options {
                 if (! is_array($opt[$k])) {
                     $opt[$k] = array($opt[$k], $val);
                 } else {
-                    $opt[$k][] = $val;
+                    # Need an intermediary to modify here because $opt[$k] returns
+                    # a scalar not a reference, so modifying it directly doesn't do much.
+                    $intermediary = $opt[$k];
+                    $intermediary[] = $val;
+                    $opt[$k] = $intermediary;
                 }
             } else {
                 $opt[$k] = $val;

--- a/tests/Util/PHPOptions/OptionsTest.php
+++ b/tests/Util/PHPOptions/OptionsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace tests\phpunit\Util;
+
+use TryLib\Util\PHPOptions\Options as Options;
+
+class OptionsTest extends \PHPUnit\Framework\TestCase {
+
+    function testParseExtraParameters() {
+        $optspec = "
+try
+--
+safelist= Generate the patch for only the safelisted files
+        ";
+
+        $actual_params = (new Options($optspec))->parse(array('--safelist', 'v1', '--safelist', 'v2', '--safelist', 'v3'));
+        list($opt,$flags,$extra) = $actual_params;
+        $this->assertEquals(['v1','v2','v3'], $opt->safelist);
+    }
+}


### PR DESCRIPTION
When specifying an option three times (e.g. `--safelist file1 --safelist file2 --safelist file3`), you'd get an error due to how subclasses of ArrayObject work (OptDict in this case).