### PR TITLE
Fix 2 bugs

### DIFF
--- a/src/Util/PHPOptions/Options.php
+++ b/src/Util/PHPOptions/Options.php
@@ -183,8 +183,8 @@ function _getopt_do_longs($opts, $opt, $longopts, $args) {
     if ($i === False) {
         $optarg = Null;
     } else {
-        $opt = substr($opt,0,$i);
         $optarg = substr($opt,$i+1);
+        $opt = substr($opt,0,$i);
     }
 
     list($has_arg, $opt) = _getopt_long_has_args($opt, $longopts);
@@ -514,7 +514,7 @@ class Options {
                 if (! is_array($opt[$k])) {
                     $opt[$k] = array($opt[$k], $val);
                 } else {
-                    $opt[$k][] = $val;
+                    $opt[$k] = array_merge($opt[$k],[$val]);
                 }
             } else {
                 $opt[$k] = $val;


### PR DESCRIPTION
On line 186 you were overwriting $opt before grabbing the optarg part of it. Doing the optarg first fixes it.
On line 517, since this is an ArrayObject, you can't append like that. Calling ->append, or probably simpler, just doing an array_merge like I did here does the trick