### PR TITLE
Imrpove array syntax and visible method name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: php
- 
+
 php:
   - 5.6
   - 7.0
   - 7.1
- 
+  - 7.2
+  - 7.3
+  - 7.4
+
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
- 
+  - composer install --prefer-source --no-interaction
+
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,17 @@
          "php": ">=5.6.0"
      },
     "require-dev": {
-        "phpunit/phpunit": ">=5.5.0",
-        "mikey179/vfsStream": "~1"
+        "phpunit/phpunit": "^5.5",
+        "mikey179/vfsstream": "~1"
     },
     "autoload": {
         "psr-4": {
             "TryLib\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "tests\\phpunit\\": "tests/"
         }
     }
 }

--- a/src/JenkinsRunner.php
+++ b/src/JenkinsRunner.php
@@ -41,8 +41,8 @@ abstract class JenkinsRunner {
         $this->try_job_name = $try_job_name;
         $this->cmd_runner = $cmd_runner;
 
-        $this->options = array();
-        $this->callbacks = array();
+        $this->options = [];
+        $this->callbacks = [];
         $this->ssh_key_path = null;
         $this->branch = null;
         $this->try_status = '';
@@ -127,7 +127,7 @@ abstract class JenkinsRunner {
      * Build the Jenkins CLI command, based on all options
      */
     function buildCLICommand($show_results, $show_progress) {
-        $command = array();
+        $command = [];
 
         if (!is_null($this->getSsKey())) {
             $command[] = '-i ' . $this->getSsKey();
@@ -153,8 +153,8 @@ abstract class JenkinsRunner {
 
     function executeCallback($callback) {
         $callback = str_replace(
-            array('${status}', '${url}'),
-            array($this->try_status, $this->try_base_url),
+            ['${status}', '${url}'],
+            [$this->try_status, $this->try_base_url],
             $callback
         );
         $this->cmd_runner->run($callback, false, true);

--- a/src/JenkinsRunner/FreeStyleProject.php
+++ b/src/JenkinsRunner/FreeStyleProject.php
@@ -11,7 +11,7 @@ class FreeStyleProject extends JenkinsRunner{
     }
 
     public function getBuildExtraArguments($show_results, $show_progress) {
-        $args = array();
+        $args = [];
 
         if ($show_results || $show_progress) {
             $args[] = '-s';

--- a/src/JenkinsRunner/MasterProject.php
+++ b/src/JenkinsRunner/MasterProject.php
@@ -28,8 +28,8 @@ class MasterProject extends JenkinsRunner{
             $cmd_runner
         );
 
-        $this->jobs = array();
-        $this->excluded_jobs = array();
+        $this->jobs = [];
+        $this->excluded_jobs = [];
 
         try {
             $this->colors = new AnsiColor();
@@ -58,7 +58,7 @@ class MasterProject extends JenkinsRunner{
     }
 
     public function getJobsList() {
-        $tryjobs = array();
+        $tryjobs = [];
         foreach ($this->jobs as $job) {
             if ( !in_array($job, $this->excluded_jobs)) {
                 $tryjobs[] = $this->try_job_prefix . '-' . $job;

--- a/src/Precheck/GitWarnOnBlocklisted.php
+++ b/src/Precheck/GitWarnOnBlocklisted.php
@@ -13,7 +13,7 @@ class GitWarnOnBlocklisted implements Precheck {
     protected $staged;
 
     function __construct(array $blocklist, $safelist = null, $staged = false) {
-        $this->safelist = $safelist ?: array();
+        $this->safelist = $safelist ?: [];
         $this->blocklist = array_diff($blocklist, $this->safelist);
         $this->staged = $staged;
     }
@@ -40,7 +40,7 @@ class GitWarnOnBlocklisted implements Precheck {
 
         $changed_files = $cmd_runner->getOutput();
 
-        $blocklisted_changed_files = array();
+        $blocklisted_changed_files = [];
 
         foreach (explode(PHP_EOL, $changed_files) as $file) {
             if (in_array($file, $this->blocklist)) {

--- a/src/RepoManager/Git.php
+++ b/src/RepoManager/Git.php
@@ -105,11 +105,11 @@ class Git implements RepoManager {
     function generateDiff($staged_only = false, $safelist = null, $lines_of_context = false) {
         $patch = $this->repo_path . "/patch.diff";
 
-        $args = array(
+        $args = [
             "--binary",
             "--no-color",
             $this->getUpstream(),
-        );
+        ];
 
         if ($staged_only) {
             $args[] = "--staged";

--- a/src/TryRunner/Runner.php
+++ b/src/TryRunner/Runner.php
@@ -28,9 +28,9 @@ final class Runner {
         $this->repo_manager = self::requireArg($repo_manager);
         $this->jenkins_runner = self::requireArg($jenkins_runner);
         $this->jenkins_cli_jar_path = self::requireArg($jenkins_cli_jar_path);
-        $this->safelisted_files = $safelisted_files ?: array();
+        $this->safelisted_files = $safelisted_files ?: [];
         $this->override_user = $override_user ?: getenv("USER");
-        $this->prechecks = $prechecks ?: array();
+        $this->prechecks = $prechecks ?: [];
         $this->options_tuple = self::requireArg($options_tuple);
         $this->ssh_key_path = $ssh_key_path;
         $this->patch = null;
@@ -58,7 +58,7 @@ final class Runner {
             if ($options->safelist) {
                 $safelist = $options->safelist;
                 if (is_string($safelist)) {
-                    $safelist = array($safelist);
+                    $safelist = [$safelist];
                 }
             } else {
                 $safelist = $this->safelisted_files;

--- a/src/Util/AnsiColor.php
+++ b/src/Util/AnsiColor.php
@@ -41,7 +41,7 @@ class AnsiColor {
         }
     }
 
-    private $color_opts = array(
+    private $color_opts = [
         'black'   => '30',
         'red'     => '31',
         'green'   => '32',
@@ -58,14 +58,14 @@ class AnsiColor {
         'ipurple' => '95',
         'icyan'   => '96',
         'iwhite'  => '97',
-    );
+    ];
 
-    private $text_opts = array(
+    private $text_opts = [
         'bold'      => '1',
         'underline' => '4',
         'blink'     => '5',
         'reverse'   => '7',
-    );
+    ];
 
     private $seq = '';
 

--- a/src/Util/OptionsUtil.php
+++ b/src/Util/OptionsUtil.php
@@ -22,7 +22,7 @@ class OptionsUtil {
       * and return an array of key->value
       */
     public static function parseExtraParameters($extra_param_option) {
-        $params = array();
+        $params = [];
         if (is_string($extra_param_option)) {
             $params[] = self::parseParam($extra_param_option);
         } elseif (is_array($extra_param_option)) {

--- a/src/Util/PHPOptions/Options.php
+++ b/src/Util/PHPOptions/Options.php
@@ -110,8 +110,8 @@ function _endswith($haystack, $needle) {
 
 function _remove_negative_kv($k, $v) {
     if ( _startswith($k, 'no-') || _startswith($k, 'no_') )
-        return array(substr($k, 3), ! $v);
-    return array($k,$v);
+        return [substr($k, 3), ! $v];
+    return [$k,$v];
 }
 
 
@@ -131,11 +131,11 @@ If the first character of the option string is `+', or if the
 environment variable POSIXLY_CORRECT is set, then option
 processing stops as soon as a non-option argument is encountered.
 **/
-function _gnu_getopt($args, $shortopts, $longopts=array()) {
-    $opts = array();
-    $prog_args = array();
+function _gnu_getopt($args, $shortopts, $longopts=[]) {
+    $opts = [];
+    $prog_args = [];
     if (is_string($longopts))
-        $longopts = array($longopts);
+        $longopts = [$longopts];
 
     // Allow options after non-option arguments?
     if (_startswith($shortopts, '+')) {
@@ -173,7 +173,7 @@ function _gnu_getopt($args, $shortopts, $longopts=array()) {
         }
     }
 
-    return array($opts, $prog_args);
+    return [$opts, $prog_args];
 }
 
 class GetoptError extends Exception { }
@@ -198,12 +198,12 @@ function _getopt_do_longs($opts, $opt, $longopts, $args) {
     } elseif ($optarg !== Null) {
         throw new GetoptError("option --$opt must not have an argument");
     }
-    array_push($opts,array('--' . $opt, $optarg ? $optarg : ''));
-    return array($opts, $args);
+    array_push($opts,['--' . $opt, $optarg ? $optarg : '']);
+    return [$opts, $args];
 }
 
 function _getopt_long_has_args($opt, $longopts) {
-    $possibilities = array();
+    $possibilities = [];
     foreach ($longopts as $o)
         if (_startswith($o,$opt))
             array_push($possibilities,$o);
@@ -211,9 +211,9 @@ function _getopt_long_has_args($opt, $longopts) {
         throw new GetoptError("option --$opt not recognized");
     // Is there an exact match?
     if (in_array($opt, $possibilities))
-        return array(False, $opt);
+        return [False, $opt];
     elseif (in_array($opt . '=', $possibilities))
-        return array(True, $opt);
+        return [True, $opt];
     // No exact match, so better be unique.
     if (count($possibilities) > 1)
         throw new GetoptError("option --$opt not a unique prefix");
@@ -222,7 +222,7 @@ function _getopt_long_has_args($opt, $longopts) {
     $has_arg = _endswith($unique_match,'=');
     if ($has_arg)
         $unique_match = substr($unique_match,0,-1);
-    return array($has_arg, $unique_match);
+    return [$has_arg, $unique_match];
 }
 
 function _getopt_do_shorts($opts, $optstring, $shortopts, $args) {
@@ -241,9 +241,9 @@ function _getopt_do_shorts($opts, $optstring, $shortopts, $args) {
         } else {
             $optarg = '';
         }
-        array_push($opts,array('-' . $opt, $optarg));
+        array_push($opts,['-' . $opt, $optarg]);
     }
-    return array($opts, $args);
+    return [$opts, $args];
 }
 
 function _getopt_short_has_arg($opt, $shortopts) {
@@ -266,8 +266,8 @@ class OptDict extends ArrayObject {
     private $_aliases;
 
     public function __construct($aliases) {
-        parent::__construct(array(), ArrayObject::STD_PROP_LIST | ArrayObject::ARRAY_AS_PROPS);
-        $this->_opts = array();
+        parent::__construct([], ArrayObject::STD_PROP_LIST | ArrayObject::ARRAY_AS_PROPS);
+        $this->_opts = [];
         $this->_aliases = $aliases;
     }
 
@@ -277,7 +277,7 @@ class OptDict extends ArrayObject {
         if (! array_key_exists($k, $this->_aliases))
             throw new Exception("KeyError: Option '$k' is unknown.");
         list($k, $invert) = $this->_aliases[$k];
-        return array($k, $invert xor $reinvert);
+        return [$k, $invert xor $reinvert];
     }
 
     public function offsetSet($k, $v) {
@@ -361,16 +361,16 @@ class Options {
         $this->optspec = $optspec;
         $this->_onabort = $onabort;
         $this->optfunc = $optfunc;
-        $this->_aliases = array();
+        $this->_aliases = [];
         $this->_shortopts = 'h?';
-        $this->_longopts = array('help', 'usage');
-        $this->_hasparms = array();
-        $this->_defaults = array();
+        $this->_longopts = ['help', 'usage'];
+        $this->_hasparms = [];
+        $this->_defaults = [];
         $this->_usagestr = $this->_gen_usage();  // this also parses the optspec
     }
 
     private function _gen_usage() {
-        $out = array();
+        $out = [];
         $lines = explode("\n", trim($this->optspec));
         $lines = array_reverse($lines);
         $first_syn = True;
@@ -399,19 +399,19 @@ class Options {
                 } else {
                     $has_parm = 0;
                 }
-                $g = array();
+                $g = [];
                 $gr = preg_match('/\[([^\]]*)\]$/', $extra, $g);
                 if ($gr)
                     $defval = _intify($g[1]);
                 else
                     $defval = Null;
                 $flagl = explode(',', $flags);
-                $flagl_nice = array();
+                $flagl_nice = [];
                 list($flag_main, $invert_main) = _remove_negative_kv($flagl[0], False);
                 $this->_defaults[$flag_main] = _invert($defval, $invert_main);
                 foreach ($flagl as $_f) {
                     list($f,$invert) = _remove_negative_kv($_f, 0);
-                    $this->_aliases[$f] = array($flag_main, $invert_main xor $invert);
+                    $this->_aliases[$f] = [$flag_main, $invert_main xor $invert];
                     $this->_hasparms[$f] = $has_parm;
                     if ($f == '#') {
                         $this->_shortopts .= '0123456789';
@@ -421,8 +421,8 @@ class Options {
                         array_push($flagl_nice, '-' . $f);
                     } else {
                         $f_nice = preg_replace('/\W/', '_', $f);
-                        $this->_aliases[$f_nice] = array($flag_main,
-                                                 $invert_main xor $invert);
+                        $this->_aliases[$f_nice] = [$flag_main,
+                                                 $invert_main xor $invert];
                         array_push($this->_longopts, $f . ($has_parm ? '=' : ''));
                         array_push($this->_longopts, 'no-' . $f);
                         array_push($flagl_nice, '--' . $_f);
@@ -490,10 +490,10 @@ class Options {
         foreach ($flags as $f) {
             $k = ltrim($f[0],'-');
             $v = $f[1];
-            if (in_array($k, array('h', '?', 'help', 'usage')))
+            if (in_array($k, ['h', '?', 'help', 'usage']))
                 $this->usage();
             if (array_key_exists('#', $this->_aliases) &&
-                  in_array($k, array('0','1','2','3','4','5','6','7','8','9'))) {
+                  in_array($k, ['0','1','2','3','4','5','6','7','8','9'])) {
                 $v = _atoi($k);  # guaranteed to be exactly one digit
                 list($k, $invert) = $this->_aliases['#'];
                 $opt['#'] = $v;
@@ -512,7 +512,7 @@ class Options {
             $val = _invert($v, $invert);
             if ( $opt[$k] != $this->_defaults[$k]) {
                 if (! is_array($opt[$k])) {
-                    $opt[$k] = array($opt[$k], $val);
+                    $opt[$k] = [$opt[$k], $val];
                 } else {
                     $opt[$k] = array_merge($opt[$k],[$val]);
                 }
@@ -520,6 +520,6 @@ class Options {
                 $opt[$k] = $val;
             }
         }
-        return array($opt,$flags,$extra);
+        return [$opt,$flags,$extra];
     }
 }

--- a/tests/JenkinsRunner/FreeStyleProjectTest.php
+++ b/tests/JenkinsRunner/FreeStyleProjectTest.php
@@ -12,7 +12,7 @@ class FreeStyleProjectTest extends \PHPUnit\Framework\TestCase {
     private $jenkins_runner;
     private $mock_cmd_runner;
 
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
 
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
@@ -26,43 +26,43 @@ class FreeStyleProjectTest extends \PHPUnit\Framework\TestCase {
         );
     }
 
-    function testGetBuildCommand() {
+    public function testGetBuildCommand() {
         $this->assertEquals('build', $this->jenkins_runner->getBuildCommand());
     }
 
-    function provideDataForBuildExtraArgs() {
-        return array(
-            array(false, false, array()),
-            array(false, true, array('-s', '-v')),
-            array(true, false, array('-s')),
-            array(true, true, array('-s', '-v')),
-        );
+    public function provideDataForBuildExtraArgs() {
+        return [
+            [false, false, []],
+            [false, true, ['-s', '-v']],
+            [true, false, ['-s']],
+            [true, true, ['-s', '-v']],
+        ];
     }
 
     /**
       * @dataProvider provideDataForBuildExtraArgs
       */
-    function testGetBuildExtraArguments($show_results, $show_progress, $expected_args) {
+    public function testGetBuildExtraArguments($show_results, $show_progress, $expected_args) {
         $actual_args = $this->jenkins_runner->getBuildExtraArguments($show_results, $show_progress);
         $this->assertEquals($expected_args, $actual_args);
     }
 
-    function providePollForCompletionData() {
-        return array(
-            array('Completed ' . self::JENKINS_JOB . ' #1234 : SUCCESS',
+    public function providePollForCompletionData() {
+        return [
+            ['Completed ' . self::JENKINS_JOB . ' #1234 : SUCCESS',
                   'SUCCESS',
-                  'http://' . self::JENKINS_URL . '/job/' . self::JENKINS_JOB .'/1234'),
+                  'http://' . self::JENKINS_URL . '/job/' . self::JENKINS_JOB .'/1234'],
 
-            array('Completed ' . self::JENKINS_JOB . ' #1 : failure',
+            ['Completed ' . self::JENKINS_JOB . ' #1 : failure',
                   'failure',
-                  'http://' . self::JENKINS_URL . '/job/' . self::JENKINS_JOB .'/1'),
+                  'http://' . self::JENKINS_URL . '/job/' . self::JENKINS_JOB .'/1'],
 
-            array('Random string', '', '')
-        );
+            ['Random string', '', '']
+        ];
     }
 
     /** @dataProvider providePollForCompletionData */
-    function testPollForCompletion($output, $status, $url){
+    public function testPollForCompletion($output, $status, $url){
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
                               ->will($this->returnValue($output));

--- a/tests/JenkinsRunner/MasterProjectTest.php
+++ b/tests/JenkinsRunner/MasterProjectTest.php
@@ -12,7 +12,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
     private $jenkins_runner;
     private $mock_cmd_runner;
 
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
 
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
@@ -26,74 +26,73 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         );
     }
 
-    function getSubjobs() {
-        return array(
-            array(
-                array(),
-                array(),
-                array(),
-            ),
-            array(
-                array('a','b','c'),
-                array(),
-                array('test-try-a','test-try-b','test-try-c')
-            ),
-            array(
-                array(),
-                array('a', 'b', 'c'),
-                array('-test-try-a','-test-try-b','-test-try-c')
-            ),
-            array(
-                array('a','b'),
-                array('c'),
-                array('test-try-a','test-try-b','-test-try-c')
-            ),
-            array(
-                array('a','b','c'),
-                array('a','c'),
-                array('test-try-b','-test-try-a','-test-try-c')
-            ),
-            array(
-                array('a','a','c'),
-                array('c','c'),
-                array('test-try-a', '-test-try-c')
-            ),
-        );
+    public function getSubjobs() {
+        return [
+            [
+                [],
+                [],
+                [],
+            ],
+            [
+                ['a','b','c'],
+                [],
+                ['test-try-a','test-try-b','test-try-c']
+            ],
+            [
+                [],
+                ['a', 'b', 'c'],
+                ['-test-try-a','-test-try-b','-test-try-c']
+            ],
+            [
+                ['a','b'],
+                ['c'],
+                ['test-try-a','test-try-b','-test-try-c']
+            ],
+            [
+                ['a','b','c'],
+                ['a','c'],
+                ['test-try-b','-test-try-a','-test-try-c']
+            ],
+            [
+                ['a','a','c'],
+                ['c','c'],
+                ['test-try-a', '-test-try-c']
+            ],
+        ];
     }
 
     /** @dataProvider getSubJobs */
-    function testGetJobList($included, $excluded, $expected_joblist) {
+    public function testGetJobList($included, $excluded, $expected_joblist) {
         $this->jenkins_runner->setSubJobs($included);
         $this->jenkins_runner->setExcludedSubJobs($excluded);
         $joblist = $this->jenkins_runner->getJobsList();
         $this->assertEquals($expected_joblist, $joblist);
     }
 
-
-    function provideShowProgressJobResultsData() {
-        return array(
-            array(
+    public function provideShowProgressJobResultsData() {
+        return [
+            [
                 '[SUCCESS] test-try-validate-css (http://link/to/job/testReport)',
                 'SUCCESS',
                 '           test-try-validate-css \e[color SUCCESS\[0m ',
-            ),
-            array(
+            ],
+            [
                 '[UNSTABLE] test-try-validate-css (http://link/to/job/testReport)',
                 'UNSTABLE',
                 '           test-try-validate-css \e[color UNSTABLE\[0m (http://link/to/job/testReport)',
-            ),
-            array(
+            ],
+            [
                 '[FAILURE] test-try-validate-css (http://link/to/job/testReport)',
                 'FAILURE',
                 '           test-try-validate-css \e[color FAILURE\[0m (http://link/to/job/testReport)',
-            )
+            ]
 
 
-        );
+        ];
     }
 
     /** @dataProvider provideShowProgressJobResultsData */
-    function testPrintJobResultSuccessAndShowProgress($log_line, $status, $expected_output) {
+    public function testPrintJobResultSuccessAndShowProgress($log_line, $status, $expected_output) {
         $jenkins_runner = $this->getMockBuilder('TryLib\JenkinsRunner\MasterProject')
                                ->setMethods(['colorStatus'])
                                ->setConstructorArgs([self::JENKINS_URL, self::JENKINS_CLI, self::JENKINS_JOB, $this->mock_cmd_runner])
@@ -115,7 +114,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($jenkins_runner->printJobResults($log_line));
     }
 
-    function testPrintJobResultNoMatch() {
+    public function testPrintJobResultNoMatch() {
         $jenkins_runner = $this->getMockBuilder('TryLib\JenkinsRunner\MasterProject')
                                ->setMethods(['colorStatus'])
                                ->setConstructorArgs([self::JENKINS_URL, self::JENKINS_CLI, self::JENKINS_JOB, $this->mock_cmd_runner])
@@ -131,7 +130,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertFalse($jenkins_runner->printJobResults("random line"));
     }
 
-    function testProcessLogOutputNotFinishedShowProgress() {
+    public function testProcessLogOutputNotFinishedShowProgress() {
         $prev_text = '
             ......... try-replication-tests (pending)
             ......... try-hphp (pending)
@@ -162,7 +161,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($new_text, $actual);
     }
 
-    function testProcessLogOutputNotFinishedDoNotShowProgress() {
+    public function testProcessLogOutputNotFinishedDoNotShowProgress() {
         $prev_text = '
             ......... try-replication-tests (pending)
             ......... try-hphp (pending)
@@ -193,7 +192,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($new_text, $actual);
     }
 
-    function testProcessLogOutputFinishedShowProgress() {
+    public function testProcessLogOutputFinishedShowProgress() {
         $prev_text = '
             ......... try-replication-tests (pending)
             ......... try-hphp (pending)
@@ -232,7 +231,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('FAILURE', $jenkins_runner->try_status);
     }
 
-    function testProcessLogOutputFinishedDoNotShowProgress() {
+    public function testProcessLogOutputFinishedDoNotShowProgress() {
         $prev_text = '
             ......... try-replication-tests (pending)
             ......... try-hphp (pending)
@@ -270,7 +269,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('SUCCESS', $jenkins_runner->try_status);
     }
 
-    function testProcessLogOutputDifferentPrefixFinishedDoNotShowProgress() {
+    public function testProcessLogOutputDifferentPrefixFinishedDoNotShowProgress() {
         $prev_text = '
             ......... bar-replication-tests (pending)
             ......... bar-hphp (pending)
@@ -308,7 +307,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('SUCCESS', $jenkins_runner->try_status);
     }
 
-    function testPollForCompletionJobUrlNotFound() {
+    public function testPollForCompletionJobUrlNotFound() {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
                               ->will($this->returnValue('no url in here'));
@@ -327,7 +326,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('', $jenkins_runner->try_base_url);
     }
 
-    function testPollForCompletionJobFinished() {
+    public function testPollForCompletionJobFinished() {
         $expected_job_url = 'http://some.other.domain:8080/job/' . self::JENKINS_JOB . '/1234';
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
@@ -349,7 +348,7 @@ class MasterProjectTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($expected_job_url, $jenkins_runner->try_base_url);
     }
 
-    function testPollForCompletionJobPollsAndFinishes() {
+    public function testPollForCompletionJobPollsAndFinishes() {
         $expected_job_url = 'http://some.other.domain:8080/job/' . self::JENKINS_JOB . '/1234';
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')

--- a/tests/JenkinsRunnerTest.php
+++ b/tests/JenkinsRunnerTest.php
@@ -13,7 +13,7 @@ class TestRunner extends JenkinsRunner{
     }
 
     public function getBuildExtraArguments($show_results, $show_progress) {
-        return array();
+        return [];
     }
 
     public function pollForCompletion($pretty) {
@@ -29,7 +29,7 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
     private $jenkins_runner;
     private $mock_cmd_runner;
 
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
 
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
@@ -48,7 +48,7 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
     /**
      * @expectedException Exception
      */
-    function testInvalidUrl() {
+    public function testInvalidUrl() {
             $this->jenkins_runner = new TestRunner(
                 'totallyvalid.com/',
                 self::JENKINS_CLI,
@@ -57,8 +57,7 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
             );
     }
 
-
-    function testRunJenkinsCommand() {
+    public function testRunJenkinsCommand() {
         $expected_cmd = 'java -jar ' . self::JENKINS_CLI . ' -s ' . self::JENKINS_URL . ' dummy-cmd';
 
         $this->mock_cmd_runner->expects($this->once())
@@ -68,27 +67,27 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
         $this->jenkins_runner->runJenkinsCommand('dummy-cmd');
     }
 
-    function testSetParam() {
+    public function testSetParam() {
         $this->jenkins_runner->setParam('foo', 'bar');
         $this->jenkins_runner->setParam('foo', 'baz');
 
         $actual = $this->jenkins_runner->getOptions();
-        $expected = array('-p foo=bar', '-p foo=baz');
+        $expected = ['-p foo=bar', '-p foo=baz'];
         $this->assertEquals($expected, $actual);
     }
 
-    function testSetDuplicateParam() {
+    public function testSetDuplicateParam() {
         $this->jenkins_runner->setParam('foo', 'bar');
         $this->jenkins_runner->setParam('foo', 'bar');
         $this->jenkins_runner->setParam('foo', 'baz');
         $this->jenkins_runner->setParam('foo', 'baz');
 
         $actual = $this->jenkins_runner->getOptions();
-        $expected = array('-p foo=bar', '-p foo=baz');
+        $expected = ['-p foo=bar', '-p foo=baz'];
         $this->assertEquals($expected, $actual);
     }
 
-    function testSetSshKeyFileExists() {
+    public function testSetSshKeyFileExists() {
         $expected = 'testDir/try_id_rsa';
         vfsStream::newFile('try_id_rsa')
             ->at(vfsStreamWrapper::getRoot());
@@ -97,61 +96,61 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('vfs://' . $expected, $this->jenkins_runner->getSsKey());
     }
 
-    function testSetSshKeyFileDoesNotExists() {
+    public function testSetSshKeyFileDoesNotExists() {
         $this->jenkins_runner->setSshKey('~/foo');
         $this->assertNull($this->jenkins_runner->getSsKey());
     }
 
-    function testPatchFileExists() {
+    public function testPatchFileExists() {
         $patch = 'testDir/patch.diff';
         vfsStream::newFile('patch.diff')
             ->at(vfsStreamWrapper::getRoot());
 
         $this->jenkins_runner->setPatch(vfsStream::url($patch));
 
-        $expected = array('-p patch.diff=vfs://' . $patch);
+        $expected = ['-p patch.diff=vfs://' . $patch];
         $this->assertEquals($expected, $this->jenkins_runner->getOptions());
     }
 
-    function testPatchFileDoesNotExists() {
+    public function testPatchFileDoesNotExists() {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('terminate')
                               ->with($this->equalTo('Patch file not found (vfs://patch.diff)'));
 
         $this->jenkins_runner->setPatch(vfsStream::url('patch.diff'));
-        $this->assertEquals(array(), $this->jenkins_runner->getOptions());
+        $this->assertEquals([], $this->jenkins_runner->getOptions());
     }
 
-    function testAddNullCallback() {
+    public function testAddNullCallback() {
         $this->jenkins_runner->addCallback(null);
-        $this->assertEquals(array(), $this->jenkins_runner->getCallbacks());
+        $this->assertEquals([], $this->jenkins_runner->getCallbacks());
     }
 
-    function testAddStringCallback() {
+    public function testAddStringCallback() {
         $callback = 'echo "Hello Test"';
         $this->jenkins_runner->addCallback($callback);
-        $this->assertEquals(array($callback), $this->jenkins_runner->getCallbacks());
+        $this->assertEquals([$callback], $this->jenkins_runner->getCallbacks());
     }
 
-    function testAddObjallback() {
+    public function testAddObjallback() {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('warn')
                               ->with($this->equalTo('Invalid callback - must be a string'));
         $this->jenkins_runner->addCallback((object) 'echo');
-        $this->assertEquals(array(), $this->jenkins_runner->getCallbacks());
+        $this->assertEquals([], $this->jenkins_runner->getCallbacks());
     }
 
-    function provideCallbackData() {
-        return array(
-            array('echo "hello world"', 'SUCCESS', 'URL', 'echo "hello world"'),
-            array('echo "${status}"', 'SUCCESS', 'URL', 'echo "SUCCESS"'),
-            array('echo "${url}"', 'SUCCESS', 'URL', 'echo "URL"'),
-            array('echo "${status} : ${url}"', 'SUCCESS', 'URL', 'echo "SUCCESS : URL"')
-        );
+    public function provideCallbackData() {
+        return [
+            ['echo "hello world"', 'SUCCESS', 'URL', 'echo "hello world"'],
+            ['echo "${status}"', 'SUCCESS', 'URL', 'echo "SUCCESS"'],
+            ['echo "${url}"', 'SUCCESS', 'URL', 'echo "URL"'],
+            ['echo "${status} : ${url}"', 'SUCCESS', 'URL', 'echo "SUCCESS : URL"']
+        ];
     }
 
     /** @dataProvider provideCallbackData */
-    function testExecuteCallback($callback, $status, $url, $expected) {
+    public function testExecuteCallback($callback, $status, $url, $expected) {
         $this->jenkins_runner->try_status = $status;
         $this->jenkins_runner->try_base_url = $url;
         $this->mock_cmd_runner->expects($this->once())
@@ -161,7 +160,7 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
     }
 
 
-    function testBuildCLICommandNoSshKey() {
+    public function testBuildCLICommandNoSshKey() {
         $this->jenkins_runner->setParam('foo', 'bar');
         $this->jenkins_runner->setParam('foo', 'baz');
 
@@ -170,7 +169,7 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($expected, $actual);
     }
 
-    function testBuildCLICommandWithSshKey() {
+    public function testBuildCLICommandWithSshKey() {
         $this->jenkins_runner->setParam('foo', 'bar');
 
         $ssh_key = 'testDir/try_id_rsa';
@@ -183,21 +182,21 @@ class JenkinsRunnerTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals($expected, $actual);
     }
 
-    function provideStartJenkinsJobParam() {
-        return array(
-            array(false, false, false, $this->never()),
-            array(true, false, false, $this->any()),
-            array(false, true, false, $this->any()),
-            array(false, false, true, $this->any()),
-            array(true, true, true, $this->any()),
-            array(false, true, true, $this->any()),
-            array(true, true, false, $this->any()),
-            array(true, false, true, $this->any()) 
-        );
+    public function provideStartJenkinsJobParam() {
+        return [
+            [false, false, false, $this->never()],
+            [true, false, false, $this->any()],
+            [false, true, false, $this->any()],
+            [false, false, true, $this->any()],
+            [true, true, true, $this->any()],
+            [false, true, true, $this->any()],
+            [true, true, false, $this->any()],
+            [true, false, true, $this->any()]
+        ];
     }
 
     /** @dataProvider provideStartJenkinsJobParam */
-    function testStartJenkinsJob($show_results, $show_progress, $has_callbacks, $expected_call_count) {
+    public function testStartJenkinsJob($show_results, $show_progress, $has_callbacks, $expected_call_count) {
         $jenkins_runner = $this->getMockBuilder('tests\phpunit\TestRunner')
                                ->setMethods(['runJenkinsCommand', 'buildCLICommand', 'pollForCompletion', 'getCallbacks', 'executeCallbacks'])
                                ->setConstructorArgs([self::JENKINS_URL, self::JENKINS_CLI, self::JENKINS_JOB, 'mock_runner'])

--- a/tests/Precheck/GitCopyAgeTest.php
+++ b/tests/Precheck/GitCopyAgeTest.php
@@ -8,37 +8,37 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
 
     private $mock_cmd_runner;
 
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                       ->getMock();
     }
 
-    function testGetLastFetchDateWithoutRemoteBranchSuccess() {
+    public function testGetLastFetchDateWithoutRemoteBranchSuccess() {
         $last_fetch = 'Sun Feb 10 10:00:00 2013';
 
         $script_runner = new GitCopyAge();
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('git log -1 --format=\'%cd\' --date=local')
                               ->will($this->returnValue(0));
-        
+
 
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
                               ->will($this->returnValue($last_fetch));
-        
-        $actual = $script_runner->getLastFetchDate($this->mock_cmd_runner); 
-        
-        $this->assertEquals($last_fetch, $actual);          
+
+        $actual = $script_runner->getLastFetchDate($this->mock_cmd_runner);
+
+        $this->assertEquals($last_fetch, $actual);
     }
-    
-    function testGetLastFetchDateWithRemoteBranchFailure() {
+
+    public function testGetLastFetchDateWithRemoteBranchFailure() {
         $last_fetch = 'Sun Feb 10 10:00:00 2013';
 
         $script_runner = new GitCopyAge(24, 48, 'branch');
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('git log -1 --format=\'%cd\' --date=local origin/branch')
@@ -46,19 +46,19 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
 
         $this->mock_cmd_runner->expects($this->never())
                               ->method('getOutput');
-                
+
         $actual = $script_runner->getLastFetchDate($this->mock_cmd_runner);
-        $this->assertNull($actual);         
+        $this->assertNull($actual);
     }
-    
-    function testWorkingCopyPastMaxBlockingAge() {
+
+    public function testWorkingCopyPastMaxBlockingAge() {
         $last_fetch = 'Sun Feb 10 10:00:00 2013';
-        
+
         $script_runner = $this->getMockBuilder('TryLib\Precheck\GitCopyAge')
                               ->setMethods(['getLastFetchDate', 'getTimeDelta', 'formatTimeDiff'])
                               ->setConstructorArgs([12, 72, 'branch'])
                               ->getMock();
-        
+
         $script_runner->expects($this->once())
                       ->method('getLastFetchDate')
                       ->with($this->mock_cmd_runner)
@@ -68,7 +68,7 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
                       ->method('getTimeDelta')
                       ->with($last_fetch)
                       ->will($this->returnValue(100 * 60 * 60));
-        
+
         $script_runner->expects($this->once())
                       ->method('formatTimeDiff')
                       ->with(100 * 60 * 60)
@@ -77,13 +77,13 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('terminate')
                               ->with($this->stringContains('you working copy is 100 hours old.'));
-        
+
         $script_runner->check($this->mock_cmd_runner, 'path', 'origin/master');
     }
 
-    function testWorkingCopyPastMaxWarningAge() {
+    public function testWorkingCopyPastMaxWarningAge() {
         $last_fetch = 'Sun Feb 10 10:00:00 2013';
-        
+
         $script_runner = $this->getMockBuilder('TryLib\Precheck\GitCopyAge')
                               ->setMethods(['getLastFetchDate', 'getTimeDelta', 'formatTimeDiff'])
                               ->setConstructorArgs([12, 72, 'branch'])
@@ -98,7 +98,7 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
                       ->method('getTimeDelta')
                       ->with($last_fetch)
                       ->will($this->returnValue(24 * 60 * 60));
-        
+
         $script_runner->expects($this->once())
                       ->method('formatTimeDiff')
                       ->with(24 * 60 * 60)
@@ -109,19 +109,19 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
 
         $this->mock_cmd_runner->expects($this->once())
                               ->method('warn');
-        
+
         $script_runner->check($this->mock_cmd_runner, 'path', 'origin/master');
     }
 
 
-    function testWorkingCopySuccess() {
+    public function testWorkingCopySuccess() {
         $last_fetch = 'Sun Feb 10 10:00:00 2013';
-        
+
         $script_runner = $this->getMockBuilder('TryLib\Precheck\GitCopyAge')
                               ->setMethods(['getLastFetchDate', 'getTimeDelta', 'formatTimeDiff'])
                               ->setConstructorArgs([12, 72, 'branch'])
                               ->getMock();
-        
+
         $script_runner->expects($this->once())
                       ->method('getLastFetchDate')
                       ->with($this->mock_cmd_runner)
@@ -131,7 +131,7 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
                       ->method('getTimeDelta')
                       ->with($last_fetch)
                       ->will($this->returnValue(6 * 60 * 60));
-        
+
         $script_runner->expects($this->never())
                       ->method('formatTimeDiff');
 
@@ -140,7 +140,7 @@ class GitCopyAgeTest extends \PHPUnit\Framework\TestCase {
 
         $this->mock_cmd_runner->expects($this->never())
                               ->method('warn');
-        
+
         $script_runner->check($this->mock_cmd_runner, 'path', 'origin/master');
     }
 }

--- a/tests/Precheck/GitCopyBehindTest.php
+++ b/tests/Precheck/GitCopyBehindTest.php
@@ -6,7 +6,7 @@ use TryLib\Precheck\GitCopyBehind as GitCopyBehind;
 
 class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
 
-    function testShouldRunCheckShouldRun() {
+    public function testShouldRunCheckShouldRun() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 
@@ -18,12 +18,12 @@ class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
                         ->method('getOutput')
                         ->will($this->returnValue('master'));
 
-        $git_copy_behind_check = new GitCopyBehind(array('master'));
+        $git_copy_behind_check = new GitCopyBehind(['master']);
 
         $this->assertTrue($git_copy_behind_check->shouldRunCheck($mock_cmd_runner));
     }
 
-    function testShouldRunCheckShouldNotRun() {
+    public function testShouldRunCheckShouldNotRun() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 
@@ -35,12 +35,12 @@ class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
                         ->method('getOutput')
                         ->will($this->returnValue('myfeature'));
 
-        $git_copy_behind_check = new GitCopyBehind(array('master'));
+        $git_copy_behind_check = new GitCopyBehind(['master']);
 
         $this->assertFalse($git_copy_behind_check->shouldRunCheck($mock_cmd_runner));
     }
 
-    function testShouldRunCheckNoBranches() {
+    public function testShouldRunCheckNoBranches() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 
@@ -52,12 +52,12 @@ class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
                         ->method('getOutput')
                         ->will($this->returnValue('master'));
 
-        $git_copy_behind_check = new GitCopyBehind(array());
+        $git_copy_behind_check = new GitCopyBehind([]);
 
         $this->assertFalse($git_copy_behind_check->shouldRunCheck($mock_cmd_runner));
     }
 
-    function testCheckWorkingCopyBehind() {
+    public function testCheckWorkingCopyBehind() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 
@@ -85,7 +85,7 @@ class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
         $script_runner->check($mock_cmd_runner, 'path', 'origin/master');
     }
 
-    function testCheckWorkingCopyNotBehind() {
+    public function testCheckWorkingCopyNotBehind() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 
@@ -113,7 +113,7 @@ class GitCopyBehindTest extends \PHPUnit\Framework\TestCase {
         $script_runner->check($mock_cmd_runner, 'path', 'origin/master');
     }
 
-    function testCheckShouldNotRun() {
+    public function testCheckShouldNotRun() {
         $mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                 ->getMock();
 

--- a/tests/Precheck/GitWarnOnBlocklistedTest.php
+++ b/tests/Precheck/GitWarnOnBlocklistedTest.php
@@ -5,15 +5,15 @@ namespace tests\phpunit\Precheck;
 use TryLib\Precheck\GitWarnOnBlocklisted as GitWarnOnBlocklisted;
 
 class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                       ->getMock();
     }
 
-    function testNoChanges() {
+    public function testNoChanges() {
         $script_runner = new GitWarnOnBlocklisted(
-            array(),
+            [],
             null,
             false
         );
@@ -34,9 +34,9 @@ class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
         $script_runner->check($this->mock_cmd_runner, 'repoPath', 'some/origin');
     }
 
-    function testNoBlockListedFiles() {
+    public function testNoBlockListedFiles() {
         $script_runner = new GitWarnOnBlocklisted(
-            array('my/foo.php'),
+            ['my/foo.php'],
             false,
             false
         );
@@ -57,9 +57,9 @@ class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    function testWithBlockListedFiles() {
+    public function testWithBlockListedFiles() {
         $script_runner = new GitWarnOnBlocklisted(
-            array('my/foo.php', 'my/bar.php'),
+            ['my/foo.php', 'my/bar.php'],
             null,
             false
         );
@@ -80,10 +80,10 @@ class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    function testWithSafeListedFiles() {
+    public function testWithSafeListedFiles() {
         $script_runner = new GitWarnOnBlocklisted(
-            array(),
-            array('my/foo.php', 'my/bar.php'),
+            [],
+            ['my/foo.php', 'my/bar.php'],
             false
         );
 
@@ -103,10 +103,10 @@ class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
 
     }
 
-    function testWithSafeListedAndBlockListedFiles() {
+    public function testWithSafeListedAndBlockListedFiles() {
         $script_runner = new GitWarnOnBlocklisted(
-            array('my/bar.php'),
-            array('my/foo.php', 'my/bar.php'),
+            ['my/bar.php'],
+            ['my/foo.php', 'my/bar.php'],
             false
         );
 
@@ -125,9 +125,9 @@ class GitWarnOnBlocklistedTest extends \PHPUnit\Framework\TestCase {
         $script_runner->check($this->mock_cmd_runner, 'repoPath', 'some/origin');
     }
 
-    function testStagedOnly() {
+    public function testStagedOnly() {
         $script_runner = new GitWarnOnBlocklisted(
-            array('my/foo.php', 'my/bar.php'),
+            ['my/foo.php', 'my/bar.php'],
             null,
             true
         );

--- a/tests/Precheck/ScriptRunnerTest.php
+++ b/tests/Precheck/ScriptRunnerTest.php
@@ -10,7 +10,7 @@ class ScriptRunnerTest extends \PHPUnit\Framework\TestCase {
 
     private $mock_cmd_runner;
 
-    function setUp() {
+    protected function setUp() {
         parent::setUp();
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                       ->getMock();
@@ -18,25 +18,25 @@ class ScriptRunnerTest extends \PHPUnit\Framework\TestCase {
         vfsStream::setup('testDir');
     }
 
-    function testScriptDoesNotExists() {
+    public function testScriptDoesNotExists() {
 
         $script_runner = new ScriptRunner(vfsStream::url('testDir/script'));
-        
+
         $this->mock_cmd_runner->expects($this->never())
                               ->method('run');
 
         $this->mock_cmd_runner->expects($this->never())
                               ->method('terminate');
-        
-        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');              
+
+        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');
     }
-    
-    function testScriptExistsAndSucceeds() {
+
+    public function testScriptExistsAndSucceeds() {
         vfsStream::newFile('script')
             ->at(vfsStreamWrapper::getRoot());
 
         $script_runner = new ScriptRunner(vfsStream::url('testDir/script'));
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('vfs://testDir/script', false, true)
@@ -44,16 +44,16 @@ class ScriptRunnerTest extends \PHPUnit\Framework\TestCase {
 
         $this->mock_cmd_runner->expects($this->never())
                               ->method('terminate');
-        
-        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');              
+
+        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');
     }
-    
-    function testScriptExistsAndFails() {
+
+    public function testScriptExistsAndFails() {
         vfsStream::newFile('script')
             ->at(vfsStreamWrapper::getRoot());
 
         $script_runner = new ScriptRunner(vfsStream::url('testDir/script'));
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('vfs://testDir/script', false, true)
@@ -62,7 +62,7 @@ class ScriptRunnerTest extends \PHPUnit\Framework\TestCase {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('terminate')
                               ->with('Failed running pre-check script vfs://testDir/script');
-        
-        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');              
+
+        $script_runner->check($this->mock_cmd_runner, 'repoPath', 'origin/master');
     }
 }

--- a/tests/RepoManager/GitTest.php
+++ b/tests/RepoManager/GitTest.php
@@ -8,24 +8,24 @@ class GitTest extends \PHPUnit\Framework\TestCase {
     const REPO_PATH = '/path/to/repo';
 
     private $mock_cmd_runner;
-    
-    function setUp() {
+
+    protected function setUp() {
         parent::setUp();
 
         $this->mock_cmd_runner = $this->getMockBuilder('TryLib\CommandRunner')
                                       ->getMock();
-    }   
-    
-    function testGenerateDiffStagedSuccessfull() {
+    }
+
+    public function testGenerateDiffStagedSuccessfull() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getUpstream'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->once())
                      ->method('getUpstream')
                      ->will($this->returnValue('origin/master'));
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('chdir')
                               ->with(self::REPO_PATH);
@@ -34,7 +34,7 @@ class GitTest extends \PHPUnit\Framework\TestCase {
         $expected_cmd = 'git -c diff.noprefix=false diff --binary '
                       . '--no-color origin/master '
                       . '--staged > '
-                      . $expected_patch;          
+                      . $expected_patch;
 
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
@@ -47,17 +47,17 @@ class GitTest extends \PHPUnit\Framework\TestCase {
         $actual_patch = $repo_manager->generateDiff(true);
         $this->assertEquals($actual_patch, $expected_patch);
     }
-    
-    function testGenerateDiffFailure() {
+
+    public function testGenerateDiffFailure() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getUpstream'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->once())
                      ->method('getUpstream')
                      ->will($this->returnValue('origin/master'));
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('chdir')
                               ->with(self::REPO_PATH);
@@ -65,29 +65,29 @@ class GitTest extends \PHPUnit\Framework\TestCase {
         $expected_patch = self::REPO_PATH . '/patch.diff';
         $expected_cmd = 'git -c diff.noprefix=false diff --binary '
                       . '--no-color origin/master > '
-                      . $expected_patch;          
+                      . $expected_patch;
 
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with($expected_cmd, false, true)
                               ->will($this->returnValue(1));
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('terminate');
 
         $repo_manager->generateDiff(false);
     }
-    
-    
-    function testParseLocalBranchSuccess() {
+
+
+    public function testParseLocalBranchSuccess() {
         $repo_manager = new Git(
             self::REPO_PATH, $this->mock_cmd_runner
         );
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('chdir')
                               ->with(self::REPO_PATH);
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('git rev-parse --abbrev-ref HEAD', true, true)
@@ -96,19 +96,19 @@ class GitTest extends \PHPUnit\Framework\TestCase {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
                               ->will($this->returnValue('refs/heads/master '));
-        
+
         $this->assertEquals('master', $repo_manager->parseLocalBranch());
     }
 
-    function testParseLocalBranchFailure() {
+    public function testParseLocalBranchFailure() {
         $repo_manager = new Git(
             self::REPO_PATH, $this->mock_cmd_runner
         );
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('chdir')
                               ->with(self::REPO_PATH);
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with('git rev-parse --abbrev-ref HEAD', true, true)
@@ -117,11 +117,11 @@ class GitTest extends \PHPUnit\Framework\TestCase {
         $this->mock_cmd_runner->expects($this->once())
                               ->method('getOutput')
                               ->will($this->returnValue("HEAD"));
-        
+
         $this->assertEquals('', $repo_manager->parseLocalBranch());
     }
-    
-    function testGetRemoteSuccess() {
+
+    public function testGetRemoteSuccess() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
@@ -138,13 +138,13 @@ class GitTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals('origin', $repo_manager->getRemote('default'));
     }
-    
-    function testGetRemoteFailWithDefault() {
+
+    public function testGetRemoteFailWithDefault() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->once())
                      ->method('getLocalBranch')
                      ->will($this->returnValue('master'));
@@ -156,8 +156,8 @@ class GitTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals('default', $repo_manager->getRemote('default'));
     }
-    
-    function testGetRemoteFailNoDefault() {
+
+    public function testGetRemoteFailNoDefault() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
@@ -174,14 +174,14 @@ class GitTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertNull($repo_manager->getRemote());
     }
-    
-    
-    function testGetRemoteBranchFromTrackingConfig() {
+
+
+    public function testGetRemoteBranchFromTrackingConfig() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->once())
                      ->method('getLocalBranch')
                      ->will($this->returnValue('local_branch'));
@@ -193,13 +193,13 @@ class GitTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals('remote_branch', $repo_manager->getRemoteBranch());
     }
-    
-    function testGetRemoteBranchNoTrackingRemoteWithSameName() {
+
+    public function testGetRemoteBranchNoTrackingRemoteWithSameName() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->at(0))
                      ->method('getLocalBranch')
                      ->will($this->returnValue('local_branch'));
@@ -208,14 +208,14 @@ class GitTest extends \PHPUnit\Framework\TestCase {
                      ->method('getConfig')
                      ->with('branch.local_branch.merge')
                      ->will($this->returnValue(null));
-        
+
         $repo_manager->expects($this->at(2))
                      ->method('getConfig')
                      ->with('remote.origin.url')
                      ->will($this->returnValue('git@github.com:Etsy/try.git'));
 
         $cmd = 'git ls-remote --exit-code git@github.com:Etsy/try.git refs/heads/local_branch';
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with($cmd, true, true)
@@ -227,13 +227,13 @@ class GitTest extends \PHPUnit\Framework\TestCase {
     /**
      * @expectedException        RuntimeException
      * @expectedExceptionMessage No remote branch was found
-     */ 
-    function testGetRemoteBranchNoTrackingNoRemote() {
+     */
+    public function testGetRemoteBranchNoTrackingNoRemote() {
         $repo_manager = $this->getMockBuilder('TryLib\RepoManager\Git')
                              ->setMethods(['getLocalBranch', 'getConfig'])
                              ->setConstructorArgs([self::REPO_PATH, $this->mock_cmd_runner])
                              ->getMock();
-        
+
         $repo_manager->expects($this->at(0))
                      ->method('getLocalBranch')
                      ->will($this->returnValue('local_branch'));
@@ -242,14 +242,14 @@ class GitTest extends \PHPUnit\Framework\TestCase {
                      ->method('getConfig')
                      ->with('branch.local_branch.merge')
                      ->will($this->returnValue(null));
-        
+
         $repo_manager->expects($this->at(2))
                      ->method('getConfig')
                      ->with('remote.origin.url')
                      ->will($this->returnValue('git@github.com:Etsy/try.git'));
 
         $cmd = 'git ls-remote --exit-code git@github.com:Etsy/try.git refs/heads/local_branch';
-        
+
         $this->mock_cmd_runner->expects($this->once())
                               ->method('run')
                               ->with($cmd, true, true)

--- a/tests/TryRunner/RunnerTest.php
+++ b/tests/TryRunner/RunnerTest.php
@@ -17,7 +17,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
 
     public function testSimple() {
         $options_tuple = Options::parse(
-            array("--branch", "testbranch", "-U", 10),
+            ["--branch", "testbranch", "-U", 10],
             "jenkins_job",
             "jenkins_job_prefix",
             "jenkins_server",
@@ -31,9 +31,9 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
             $repo_manager,
             $jenkins_runner,
             "test_cli_jar_path",
-            array(),
+            [],
             "test_user",
-            array(),
+            [],
             $options_tuple,
             "/test/ssh/key/path"
         );
@@ -56,7 +56,7 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
      */
     public function testHonorRemoteBranch() {
         $options_tuple = Options::parse(
-            array(),
+            [],
             "jenkins_job",
             "jenkins_job_prefix",
             "jenkins_server",
@@ -70,9 +70,9 @@ class RunnerTest extends \PHPUnit\Framework\TestCase {
             $repo_manager,
             $jenkins_runner,
             "test_cli_jar_path",
-            array(),
+            [],
             "test_user",
-            array(),
+            [],
             $options_tuple,
             "/test/ssh/key/path"
         );
@@ -129,7 +129,7 @@ class TestRepoManagerWithDetectedBranch
 
 class TestJenkinsRunner extends JenkinsRunner {
 
-    public $commands_run = array();
+    public $commands_run = [];
     public $ssh_key_path = null;
 
     protected function pollForCompletion($pretty) {}

--- a/tests/Util/OptionsUtilTest.php
+++ b/tests/Util/OptionsUtilTest.php
@@ -6,45 +6,45 @@ use TryLib\Util\OptionsUtil as OptionsUtil;
 
 class OptionsUtilTest extends \PHPUnit\Framework\TestCase {
 
-    function provideExtraParameters() {
-        return array(
-            array(
+    public function provideExtraParameters() {
+        return [
+            [
                 null,
-                array()
-            ),
-            array(
+                []
+            ],
+            [
                 'k=v',
-                array(
-                    array('k','v')
-                )
-            ),
-            array(
+                [
+                    ['k','v']
+                ]
+            ],
+            [
                 'k',
-                array(
-                    array('k','')
-                )
-            ),
-            array(
+                [
+                    ['k','']
+                ]
+            ],
+            [
                 'k=v=w',
-                array(
-                    array('k','v=w')
-                )
-            ),
-            array(
-                array('k=v','x=y=z','w'),
-                array(
-                    array('k','v'),
-                    array('x','y=z'),
-                    array('w',''),
-                )
-            ),
-        );
+                [
+                    ['k','v=w']
+                ]
+            ],
+            [
+                ['k=v','x=y=z','w'],
+                [
+                    ['k','v'],
+                    ['x','y=z'],
+                    ['w',''],
+                ]
+            ],
+        ];
     }
 
     /**
       * @dataProvider provideExtraParameters
       */
-    function testParseExtraParameters($extra_param_option, $expected_params) {
+    public function testParseExtraParameters($extra_param_option, $expected_params) {
         $actual_params = OptionsUtil::parseExtraParameters($extra_param_option);
         $this->assertEquals($expected_params, $actual_params);
     }


### PR DESCRIPTION
# Changed log

- Add `php-7.2`,`php-7.3` and `php-7.4` tests during Travis CI build.
- It's time to use the short array syntax to replace `array` syntax because this package requires `php-5.6` at least.
- Remove additional white spaces on all PHP codes.